### PR TITLE
fix: graphics were not showing due undefined value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,8 @@ This tool can also be used programmatically
   }, (err, result) => {
     if (err) throw err
 
-    reporter.buildReport(result) // the html structure
-    reporter.writeReport(result, reportOutputPath, (err, res) => {
+    var report = reporter.buildReport(result, []) // the html structure
+    reporter.writeReport(report, reportOutputPath, (err, res) => {
       if (err) console.err('Error writting report: ', err)
       else console.log('Report written to: ', reportOutputPath)
     }) //write the report

--- a/template/partials/scripts.js
+++ b/template/partials/scripts.js
@@ -2,7 +2,7 @@
 module.exports = function (results, compare) {
   return `
     var results = ${JSON.stringify(results)}
-    var compare = ${JSON.stringify(compare)}
+    var compare = ${JSON.stringify(compare) || []}
     ${prettyBytes.toString()}
     ${growDiv.toString()}
     ${main.toString()}


### PR DESCRIPTION
Updating readme, fixing an issue when not sending `compare` when building a report.

If  `compare` is empty, graphics get an error.
![image](https://user-images.githubusercontent.com/7978236/159753052-bf914ec9-11f9-473c-b5a5-16a78997936c.png)


Before:
![image](https://user-images.githubusercontent.com/7978236/159752900-6f42841d-0c6e-4f3d-944f-e19fd820abd9.png)

After:

![image](https://user-images.githubusercontent.com/7978236/159752951-c23cc314-7701-471e-9d0c-edd06e8850f1.png)

Issues related:

- https://github.com/GlenTiki/autocannon-reporter/issues/15
- https://github.com/GlenTiki/autocannon-reporter/issues/14
- https://github.com/GlenTiki/autocannon-reporter/issues/13